### PR TITLE
Add documentation to usage and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ The response bit in the Tag field is ignored due the fact there is no known need
 Ths lib is in early stage.
 
 # Usage
+There are multiple user levels (NO_AUTH => USER ... => ADMIN => E3DC_ROOT). For most cases NO_AUTH and USER level access is enough. 
+Therefore before sending a request towards you E3DC system we need to authenticate first. 
+
+Every requests towards RSCP system consists of a rscp::Frame (container) with multiple rscp::Item with the later holding the tags and data.   
+
+## Login and First Frame
+`RSCP_KEY` is the password you define on your S10 screen in Settings => Personalize => User Profile +> local.user    
+`RSCP_USER` is  is the username (i.e. email ) in your S10 portal.  
+`RSCP_PASSWORD` is the password in your S10 portal 
 
 ```rust
 use rscp::GetItem;
@@ -43,3 +52,54 @@ match c.send_receive_frame(&info_frame) {
 
 c.disconnect().unwrap();
 ```
+
+## Compose Battery Information Request
+
+Similarly to the official example of the rscp call to request battery information, we can also define a containered request. The `BAT::DATA` tag defines that the following tags 
+should be evaluated to receive some data about the battery. 
+```rust
+let mut battery_info_frame = Frame::new();
+battery_info_frame.push_item(rscp::Item::new(rscp::tags::BAT::DATA.into(),
+    vec![
+        rscp::Item { tag: rscp::tags::BAT::INDEX.into(), data: Some(Box::new(0)), },
+        rscp::Item { tag: rscp::tags::BAT::RSOC.into(), data: None },
+        rscp::Item { tag: rscp::tags::BAT::MODULE_VOLTAGE.into(), data: None },
+        rscp::Item { tag: rscp::tags::BAT::CURRENT.into(), data: None },
+        rscp::Item { tag: rscp::tags::BAT::STATUS_CODE.into(), data: None },
+        rscp::Item { tag: rscp::tags::BAT::ERROR_CODE.into(), data: None },
+    ]));
+```
+
+Expected output of `println!("Result: {:?}", result_frame.items.get_item(DATA.into()));` inside `match`
+
+```rust
+Result: Ok(Item 
+{ tag: "BAT_DATA", data: [
+    Item { tag: "BAT_INDEX", data: 0 }, 
+    Item { tag: "BAT_RSOC", data: 38.218014 }, 
+    Item { tag: "BAT_MODULE_VOLTAGE", data: 51.7 }, 
+    Item { tag: "BAT_CURRENT", data: 108.9 }, 
+    Item { tag: "BAT_STATUS_CODE", data: 0 }, 
+    Item { tag: "BAT_ERROR_CODE", data: 0 }
+] })
+```
+
+## Tags vs Tags
+Be careful which tag you use in your requests because some tags set values instead of getting them. The official example app documentation and excel table provide necessary information
+to distinguish between these tags. 
+
+The structure of tags in this project is similar to the documentation of tags but not necessarily to the tags in the official example app. 
+For Example this official tag: `#define TAG_BAT_INDEX 0x03040001` corresponds to project tag:
+
+rscp::tags::BAT::INDEX: 
+- BAT = 0x03,
+- INDEX = 0x040001,
+
+The advantage lies in the reuse of tag names and therefore in readability of code. 
+
+| Project Tags           | Example App Tags               |
+-------------------------|--------------------------------|
+| PVI::DATA = 0x040000,  | TAG_PVI_DATA = 0x02840000      |
+| BAT::DATA = 0x040000,  | TAG_BAT_INDEX = 0x03840000     |
+| DCDC::DATA = 0x040000, | TAG_DCDC_REQ_DATA = 0x04040000 |
+| ...                    | ...                            |


### PR DESCRIPTION
Hi Sven, 

- I have found some time to improve documentation in usage of this lib. 
- These were also the points which surfaced while using the lib. 
- The usage of Item::new() and Item {} is intentional to avoid erros with None. 
- Rust cannot resolve None in Item::new() usage. 
- If you are missing something, I will gladly add it. 

Just a friendly heads up: Next PR will probably tackle PartialEq for Frame and Item to allow me to write better tests. 